### PR TITLE
set chrome options in chrome process and apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ To use `recipe` in for template rendering set `template.recipe=chrome-pdf` in th
 }
 ```
 
+To set chrome options inside chrome process add the following example script to your template:
+
+```js
+//example settings, all options are available     
+window.JSREPORT_CHROME_SETTINGS = {
+    marginTop:'3cm',
+    marginBottom:'3cm',
+    marginLeft: '3cm',
+    marginRight: '3cm',
+    landscape: true,
+    format: 'Legal'
+    
+}
+
+window.JSREPORT_READY_TO_START = true;
+```
+
 ## jsreport-core
 You can apply this extension also manually to [jsreport-core](https://github.com/jsreport/jsreport-core)
 

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -167,7 +167,7 @@ function execute (reporter, definition) {
           if (chrome.waitForJS === true || chrome.waitForJS === 'true') {
             reporter.logger.debug('Chrome will wait for printing trigger', req)
             await page.waitForFunction('window.JSREPORT_READY_TO_START === true', { timeout: definition.options.timeout })
-            var newChromeSettings = await page.evaluate( () => window.JSREPORT_CHROME_SETTINGS )
+            var newChromeSettings = await page.evaluate(() => window.JSREPORT_CHROME_SETTINGS)
             chrome = Object.assign(chrome, newChromeSettings)
             chrome.margin = {
               top: chrome.marginTop,

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -99,7 +99,7 @@ function execute (reporter, definition) {
             reporter.logger.debug(m.text(), { timestamp: new Date().getTime(), ...req })
           })
 
-          const chrome = Object.assign({}, req.template.chrome)
+          let chrome = Object.assign({}, req.template.chrome)
           chrome.scale = floatOrUndefined(chrome.scale)
           chrome.landscape = boolOrUndefined(chrome.landscape)
           chrome.printBackground = boolOrUndefined(chrome.printBackground)
@@ -167,6 +167,14 @@ function execute (reporter, definition) {
           if (chrome.waitForJS === true || chrome.waitForJS === 'true') {
             reporter.logger.debug('Chrome will wait for printing trigger', req)
             await page.waitForFunction('window.JSREPORT_READY_TO_START === true', { timeout: definition.options.timeout })
+            var newChromeSettings = await page.evaluate( () => window.JSREPORT_CHROME_SETTINGS )
+            chrome = Object.assign(chrome, newChromeSettings)
+            chrome.margin = {
+              top: chrome.marginTop,
+              right: chrome.marginRight,
+              bottom: chrome.marginBottom,
+              left: chrome.marginLeft
+            }
           }
 
           if (timeoutInfo.error) {


### PR DESCRIPTION
This feature allows in browser scripts to set chrome.pdf() options before setting the JSREPORT_READY_TO_START = true.